### PR TITLE
Workaround bad <scm><tag> in some release versions of Velocity

### DIFF
--- a/scm-info/org/apache/velocity/scm.yaml
+++ b/scm-info/org/apache/velocity/scm.yaml
@@ -1,0 +1,8 @@
+---
+type: "git"
+uri: "https://github.com/apache/velocity-engine.git"
+tagMapping:
+  # Workaround bad <scm><tag> in some release versions - see https://issues.apache.org/jira/browse/VELOCITY-990
+  - pattern: (.*)
+    tag: $1
+


### PR DESCRIPTION
https://issues.apache.org/jira/browse/VELOCITY-990